### PR TITLE
Debug reading of aspell output

### DIFF
--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -3,32 +3,30 @@
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::process::ChildStdout;
-use std::io::Read;
+use std::io::{BufReader, BufRead};
 use std::sync::mpsc::Sender;
 
 use error::Result;
 
-const BUF_LEN: usize = 42;
 
 /// An asynchronous reader, that reads from a spawned command stdout
 /// and sends it to a channel
 pub struct AsyncReader {
-    stdout: ChildStdout,
+    stdout: BufReader<ChildStdout>,
     sender: Sender<Result<String>>,
-
 }
 
 impl AsyncReader {
     /// Create a new AsyncReader
     pub fn new(stdout: ChildStdout, sender: Sender<Result<String>>) -> AsyncReader {
         AsyncReader {
-            stdout: stdout,
+            stdout: BufReader::new(stdout),
             sender: sender,
         }
     }
-    
+
     /// Reads the output from ispell and sends it over the channel
-    pub fn read_loop(&mut self)  {
+    pub fn read_loop(&mut self) {
         loop {
             let result = self.read();
             match self.sender.send(result) {
@@ -40,18 +38,14 @@ impl AsyncReader {
 
     /// Reads a string
     fn read(&mut self) -> Result<String> {
-        let mut buffer = [0; BUF_LEN];
-        let mut output = vec!();
+        let mut output = String::new();
         loop {
-            let n = try!(self.stdout.read(&mut buffer));
-            output.extend_from_slice(&buffer[0..n]);
-            if n < BUF_LEN {
+            try!(self.stdout.read_line(&mut output));
+            if output.ends_with("\n\n") || output == "\n" || output.starts_with("@") {
                 break;
-            } else {
-                continue;
             }
         }
-        let s = try!(String::from_utf8(output));
-        Ok(s)
+        Ok(output)
     }
 }
+

--- a/src/spell_checker.rs
+++ b/src/spell_checker.rs
@@ -140,10 +140,6 @@ impl SpellChecker {
     /// }
     /// ```
     pub fn add_word_to_dictionary(&mut self, word: &str) -> Result<()> {
-        if word.contains(|c:char| !c.is_alphabetic()) {
-            return Err(Error::invalid_word(format!("word '{}' contains non alphabetic characters",
-                                                   word)));
-        }
         try!(self.stdin.write_all(b"*"));
         try!(self.stdin.write_all(word.as_bytes()));
         try!(self.stdin.write_all(b"\n"));
@@ -186,10 +182,6 @@ impl SpellChecker {
     /// }
     /// ```
     pub fn add_word(&mut self, word: &str) -> Result<()> {
-        if word.contains(|c:char| !c.is_alphabetic()) {
-            return Err(Error::invalid_word(format!("word '{}' contains non alphabetic characters",
-                                                   word)));
-        }
         try!(self.stdin.write_all(b"@"));
         try!(self.stdin.write_all(word.as_bytes()));
         try!(self.stdin.write_all(b"\n"));
@@ -228,22 +220,13 @@ impl SpellChecker {
     /// errors, will be more useful.
     pub fn check_raw(&mut self, text: &str) -> Result<Vec<IspellResult>> {
         try!(self.write_str(text));
-
     
-        let n_words = text.split_whitespace().count();
-        let mut output = Vec::with_capacity(n_words);
-        let mut n_lines = 0;
+        let mut output = Vec::new();
 
-        
-        while n_lines < n_words {
-            let s = try!(self.read_str());
+        if let Ok(s) = self.read_str() {
             for line in s.lines() {
-                if n_lines >= n_words {
-                    break;
-                }
-                n_lines += 1;
                 if line.is_empty() {
-                    continue;
+                    break;
                 }
                 let first = line.chars().next().unwrap();
                 match first {


### PR DESCRIPTION
The idea on this new reading mode is to stop reading only when getting a blank line (or the `^@.*` opening line)
Previously it was bugging when aspell was too slow to fill the buffer (reading the next lines in next call to check).

Another change is to remove the check for non-alphabetic chars in inputs of add_word_to_dictionnary. Our use on that is to add some city name like `L'Haÿ-les-Roses` which is ok to aspell, but was blocked by this test.
Now the `invalid_word` error is not used anymore, so maybe we should clean it.
The clean way to test that and return an error to the crate user may be to read stderr and return those errors, but...
Another way could be to just check for digits and maybe spaces (but it's too short).


:warning: Warning: this was only tested with aspell (check words, add words to temp dictionnary).
Otherwise on my platform, `cargo test` is ok when using american dictionnary for ispell (as it doesn't come packaged with british one on debian).